### PR TITLE
Set timeout only if opening bucket

### DIFF
--- a/lib/connect-couchbase.js
+++ b/lib/connect-couchbase.js
@@ -127,13 +127,12 @@ module.exports = function(session){
                     console.log("Could not connect to couchbase with bucket: " + connectOptions.bucket);
                     self.emit('disconnect', err);
                 } else {
+                    this.client.connectionTimeout = connectOptions.connectionTimeout || 10000;
+                    this.client.operationTimeout = connectOptions.operationTimeout || 10000;
                     self.emit('connect');
                 }
             });
         }
-
-        this.client.connectionTimeout = connectOptions.connectionTimeout || 10000;
-        this.client.operationTimeout = connectOptions.operationTimeout || 10000;
 
         this.ttl = options.ttl || null;
     }


### PR DESCRIPTION
Set connectionTimeout and operationTimeout only if opening a bucket.
If using an existing bucket with the db property, the timeout properties will not be changed.